### PR TITLE
Add message history endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is a simple yet powerful real-time chat application that allows users to se
 - Messages stored in a PostgreSQL database
 - WebSocket server configured with Spring Boot
 - Auto-scroll to the newest message
+- Load previous messages on startup via REST API
 - Responsive design with Material-UI
 
 ---
@@ -42,12 +43,14 @@ This is a simple yet powerful real-time chat application that allows users to se
    - Listens for incoming messages on `/app/sendMessage`
    - Saves each message into the PostgreSQL database
    - Broadcasts new messages to `/topic/messages`
+   - Exposes REST endpoint `/api/messages` to fetch stored messages
 
 2. **Frontend**
    - Connects to the backend using WebSocket
    - Subscribes to `/topic/messages` to receive real-time updates
    - Sends messages using the STOMP protocol
    - Displays messages in a styled chat card
+   - Fetches existing messages on page load
 
 ---
 

--- a/chat-frontend/src/Chat.js
+++ b/chat-frontend/src/Chat.js
@@ -24,6 +24,13 @@ export default function Chat() {
   const messagesEndRef = useRef(null);
 
   useEffect(() => {
+    fetch('http://localhost:8080/api/messages')
+      .then(res => res.json())
+      .then(data => setMessages(data))
+      .catch(err => console.error('Failed to load messages', err));
+  }, []);
+
+  useEffect(() => {
     const client = new Client({
       webSocketFactory: () => new SockJS('http://localhost:8080/ws'),
       onConnect: () => {

--- a/src/main/java/com/example/chat_backend/config/CorsConfig.java
+++ b/src/main/java/com/example/chat_backend/config/CorsConfig.java
@@ -13,7 +13,7 @@ public class CorsConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOrigins("http://localhost:3002")
+                        .allowedOrigins("http://localhost:3000")
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("*")
                         .allowCredentials(true);

--- a/src/main/java/com/example/chat_backend/controller/ChatController.java
+++ b/src/main/java/com/example/chat_backend/controller/ChatController.java
@@ -7,6 +7,9 @@ import com.example.chat_backend.repository.UserRepository;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.data.domain.Sort;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -20,6 +23,12 @@ public class ChatController {
     public ChatController(MessageRepository messageRepository, UserRepository userRepository) {
         this.messageRepository = messageRepository;
         this.userRepository = userRepository;
+    }
+
+    @GetMapping("/api/messages")
+    @ResponseBody
+    public java.util.List<Message> getMessages() {
+        return messageRepository.findAll(Sort.by(Sort.Direction.ASC, "timestamp"));
     }
 
     @MessageMapping("/sendMessage")


### PR DESCRIPTION
## Summary
- expose REST API `/api/messages` for chat history
- allow frontend on default port
- load chat history on startup via fetch
- document the new features

## Testing
- `mvn -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68811dd5a2a0832a98c7e3b1090554ea